### PR TITLE
Fix create-react-app options in "02-ts-react-basic.md"

### DIFF
--- a/using-typescript/02-ts-react-basic.md
+++ b/using-typescript/02-ts-react-basic.md
@@ -9,7 +9,7 @@
 타입스크립트를 사용하는 리액트 프로젝트를 만들때는 다음과 같이 명령어를 사용하세요.
 
 ```bash
-$ npx create-react-app ts-react-tutorial --typescript
+$ npx create-react-app ts-react-tutorial --template typescript
 ```
 
 위와 같이 뒤에 `--typescript` 가 있으면 타입스크립트 설정이 적용된 프로젝트가 생성된답니다.


### PR DESCRIPTION
[2. 리액트 컴포넌트 타입스크립트로 작성하기](https://react.vlpt.us/using-typescript/02-ts-react-basic.html#)

create-react-app option에서 `--template` 이 추가되면서 해당 스크립트가 동작안하고 있습니다. 🙏
 
Edit 'create-react-app' options
ref : https://create-react-app.dev/docs/adding-typescript/